### PR TITLE
Implement beacon_helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.pyc
+/__pycache__
+venv
+.venvs
+.venv
+/.pytest_cache
+.ipynb_checkpoints/
+*.egg-info

--- a/beacon_helpers.py
+++ b/beacon_helpers.py
@@ -1,0 +1,88 @@
+from typing import Optional
+
+from eth.rlp.headers import BlockHeader
+from eth.constants import (
+    ZERO_HASH32,
+    EMPTY_UNCLE_HASH,
+    BLANK_ROOT_HASH,
+)
+from eth.vm.forks.berlin.transactions import (
+    BerlinTransactionBuilder,
+)
+from eth.db.trie import make_trie_root_and_nodes
+
+import eth2spec.merge.spec as spec
+
+
+#
+# Beacon chain
+#
+def _get_pow_block(block_hash: spec.Hash32, _eth1_rpc: Optional['Eth1Rpc'] = None) -> spec.PowBlock:
+    # Workaroud: since the stub interface doesn't pass `eth1_rpc`, use global eth1_rpc
+    global eth1_rpc
+    # Pytest
+    if _eth1_rpc != None:
+        eth1_rpc = _eth1_rpc
+
+    pow_block = spec.PowBlock(
+        block_hash=block_hash,
+        is_processed=False,
+        is_valid=False,
+        total_difficulty=0,
+    )
+    if eth1_rpc.is_accepted_block(block_hash):
+        block = eth1_rpc.get_block_by_hash(block_hash)
+        pow_block.is_processed = True
+        pow_block.is_valid = True
+        pow_block.total_difficulty = eth1_rpc.get_score(block_hash)
+    return pow_block
+
+
+def _verify_execution_state_transition(execution_payload: spec.ExecutionPayload, _eth1_rpc: Optional['Eth1Rpc'] = None) -> bool:
+    # Workaroud: since the stub interface doesn't pass `eth1_rpc`, use global eth1_rpc
+    global eth1_rpc
+    # Pytest
+    if _eth1_rpc != None:
+        eth1_rpc = _eth1_rpc
+
+    # Compute transaction_root
+    txs = []
+    for opaque_tx in execution_payload.transactions:
+        decoded_tx = BerlinTransactionBuilder.deserialize(opaque_tx)
+        txs.append(decoded_tx)
+    transaction_root, _ = make_trie_root_and_nodes(txs)
+
+    # Verify block hash is correct
+    pow_block_header = BlockHeader(
+        difficulty=1,
+        block_number=execution_payload.number,
+        gas_limit=execution_payload.gas_limit,
+        timestamp=execution_payload.timestamp,
+        coinbase=execution_payload.coinbase,
+        parent_hash=execution_payload.parent_hash,
+        uncles_hash=EMPTY_UNCLE_HASH,
+        state_root=execution_payload.state_root,
+        transaction_root=transaction_root,
+        receipt_root=execution_payload.receipt_root,
+        bloom=0,  # TODO
+        gas_used=execution_payload.gas_used,
+        extra_data=b'',
+        mix_hash=ZERO_HASH32,
+        nonce=b'\x00' * 8,
+    )
+    if execution_payload.block_hash != pow_block_header.hash:
+        return False
+
+    # Assumption: Eth1 p2p has gossiped the block already
+    return eth1_rpc.is_accepted_block(execution_payload.block_hash)
+
+
+#
+# Validator
+#
+def _get_pow_chain_head() -> spec.PowBlock:
+    return eth1_rpc.get_head_block()
+
+
+def _produce_execution_payload(parent_hash: spec.Hash32, timestamp: spec.uint64) -> spec.ExecutionPayload:
+    ...

--- a/eth1.py
+++ b/eth1.py
@@ -1,10 +1,40 @@
+from typing import Iterable
+
+from eth_typing import (
+    Address,
+    Hash32,
+)
 # Eth1 (py-evm) imports
 from eth.chains.base import MiningChain, Chain
-from eth.vm.forks import IstanbulVM
+from eth.vm.forks import BerlinVM
 import eth.tools.builder.chain as builder
 from eth.exceptions import BlockNotFound, HeaderNotFound
 from eth_utils import encode_hex
 from eth.constants import GENESIS_PARENT_HASH
+from eth.abc import (
+    AtomicDatabaseAPI,
+    BlockHeaderAPI,
+    ConsensusAPI,
+)
+
+
+class MergedConsensus(ConsensusAPI):
+    def __init__(self, base_db: AtomicDatabaseAPI) -> None:
+        pass
+
+    def validate_seal(self, header: BlockHeaderAPI) -> None:
+        return
+
+    def validate_seal_extension(self,
+                                header: BlockHeaderAPI,
+                                parents: Iterable[BlockHeaderAPI]) -> None:
+        # NOTE: Do not check PoW seal
+        pass
+
+    @classmethod
+    def get_fee_recipient(cls, header: BlockHeaderAPI) -> Address:
+        return header.coinbase
+
 
 # These are the required RPC methods from the Eth1 node
 class Eth1Rpc:
@@ -64,6 +94,7 @@ class Eth1Rpc:
 
     def is_accepted_block(self, block_hash):
         try:
+            print('self.chain.get_block_by_hash(block_hash)',  self.chain.get_block_by_hash(block_hash))
             self.chain.get_block_by_hash(block_hash)
             return True
         except (BlockNotFound, HeaderNotFound):

--- a/eth1.py
+++ b/eth1.py
@@ -94,7 +94,6 @@ class Eth1Rpc:
 
     def is_accepted_block(self, block_hash):
         try:
-            print('self.chain.get_block_by_hash(block_hash)',  self.chain.get_block_by_hash(block_hash))
             self.chain.get_block_by_hash(block_hash)
             return True
         except (BlockNotFound, HeaderNotFound):

--- a/tests/beacon_helpers/test_beacon_helpers.py
+++ b/tests/beacon_helpers/test_beacon_helpers.py
@@ -27,7 +27,7 @@ from beacon_helpers import (
 @pytest.fixture
 def eth1_rpc():
     # Hack BerlinVM
-    BerlinVM.consensus_class = MergedConsensus
+    # BerlinVM.consensus_class = MergedConsensus
     Eth1Chain = builder.build(
         MiningChain,
         builder.fork_at(BerlinVM, 0),

--- a/tests/beacon_helpers/test_beacon_helpers.py
+++ b/tests/beacon_helpers/test_beacon_helpers.py
@@ -1,0 +1,88 @@
+from copy import deepcopy
+import pytest
+from eth.constants import (
+    ZERO_HASH32,
+    EMPTY_UNCLE_HASH,
+)
+from eth.chains.base import MiningChain, Chain
+from eth.vm.forks import BerlinVM
+from eth.vm.forks.berlin.transactions import (
+    BerlinTransactionBuilder,
+)
+import eth.tools.builder.chain as builder
+from eth.rlp.headers import BlockHeader
+from eth_bloom import BloomFilter
+
+import eth2spec.merge.spec as spec
+
+from eth1 import (
+    Eth1Rpc,
+    MergedConsensus,
+)
+from beacon_helpers import (
+    _verify_execution_state_transition,
+)
+
+
+@pytest.fixture
+def eth1_rpc():
+    # Hack BerlinVM
+    BerlinVM.consensus_class = MergedConsensus
+    Eth1Chain = builder.build(
+        MiningChain,
+        builder.fork_at(BerlinVM, 0),
+        builder.disable_pow_check(),
+    )
+    # Eth1Chain = builder.enable_pow_mining(Eth1Chain)
+    eth1_rpc = Eth1Rpc(Eth1Chain)
+    return eth1_rpc
+
+
+def test_verify_execution_state_transition(eth1_rpc):
+    # TODO: test transactions
+    # transaction = BerlinTransactionBuilder.create_unsigned_transaction(cls,
+    #     *,
+    #     nonce: int,
+    #     gas_price: int,
+    #     gas: int,
+    #     to: Address,
+    #     value: int,
+    #     data: bytes
+    # )
+
+    head_block = eth1_rpc.get_head_block()
+    assert head_block.header.block_number == 0
+
+    # Build block with a separate instance
+    new_eth1_rpc = deepcopy(eth1_rpc)
+    parent_hash = head_block.header.hash
+    new_block = new_eth1_rpc.consensus_assembleBlock(
+        extra_data=b'fork', parent_hash=parent_hash)
+
+    new_block = new_block.copy(
+        header=new_block.header.copy(
+            bloom=0,  # TODO
+            difficulty=1,  # Fixed
+            uncles_hash=EMPTY_UNCLE_HASH,  # Fixed
+            mix_hash=ZERO_HASH32,  # Fixed
+            nonce=b'\x00' * 8,  # Fixed
+            extra_data=b"",  # Fixed
+        ),
+    )
+    eth1_rpc.consensus_newBlock(new_block)
+    header = new_block.header
+    execution_payload = spec.ExecutionPayload(
+        block_hash=header.hash,
+        parent_hash=header.parent_hash,
+        coinbase=header.coinbase,
+        state_root=header.state_root,
+        number=header.block_number,
+        gas_limit=header.gas_limit,
+        gas_used=header.gas_used,
+        timestamp=header.timestamp,
+        receipt_root=header.receipt_root,
+        logs_bloom=b'\x00' * spec.BYTES_PER_LOGS_BLOOM,
+        transactions=[],
+    )
+
+    assert _verify_execution_state_transition(execution_payload, eth1_rpc)

--- a/tests/eth1/unittests/test_new_rpc_methods.py
+++ b/tests/eth1/unittests/test_new_rpc_methods.py
@@ -1,14 +1,20 @@
 import pytest
-from eth1 import Eth1Rpc
+from eth1 import (
+    Eth1Rpc,
+    MergedConsensus,
+)
 from eth.chains.base import MiningChain, Chain
-from eth.vm.forks import IstanbulVM
+from eth.vm.forks import BerlinVM
 import eth.tools.builder.chain as builder
 from copy import deepcopy
 
 @pytest.fixture
 def eth1_rpc():
     # Initialize Eth1 chain builder
-    Eth1Chain = builder.build(MiningChain, builder.fork_at(IstanbulVM, 0))
+    BerlinVM.consensus_class = MergedConsensus
+    Eth1Chain = builder.build(
+        MiningChain,builder.fork_at(BerlinVM, 0)
+    )
     Eth1Chain = builder.enable_pow_mining(Eth1Chain)
     eth1_rpc = Eth1Rpc(Eth1Chain)
     return eth1_rpc

--- a/tests/eth1/unittests/test_new_rpc_methods.py
+++ b/tests/eth1/unittests/test_new_rpc_methods.py
@@ -11,9 +11,11 @@ from copy import deepcopy
 @pytest.fixture
 def eth1_rpc():
     # Initialize Eth1 chain builder
-    BerlinVM.consensus_class = MergedConsensus
+    # BerlinVM.consensus_class = MergedConsensus
     Eth1Chain = builder.build(
-        MiningChain,builder.fork_at(BerlinVM, 0)
+        MiningChain,
+        builder.fork_at(BerlinVM, 0),
+        builder.disable_pow_check(),
     )
     Eth1Chain = builder.enable_pow_mining(Eth1Chain)
     eth1_rpc = Eth1Rpc(Eth1Chain)


### PR DESCRIPTION
This branch includes PR#1 commits. It would be good to merge #1 sooner.


Changelog:
- Add `beacon_helpers.py`. Some logic is copied from @adiasg's `Eth2-Merge-PoC.ipynb`.
- Add basic `test_verify_execution_state_transition` without testing transactions.
- Change to `BerlinVM` so that we can use EIP-2718
- ~~Define a stub `MergedConsensus` and set VM's `consensus_class` so that we can pass the tests.~~ Updated: Use `disable_pow_check` API instead.
    - There should be a new VM on py-evm side eventually.

TODO:
- [ ] Test transactions
